### PR TITLE
The complete text overlaps with the tick icon on transaction details screen.

### DIFF
--- a/brd-ios/breadwallet/src/ViewModels/TxDetailViewModel.swift
+++ b/brd-ios/breadwallet/src/ViewModels/TxDetailViewModel.swift
@@ -49,8 +49,7 @@ struct TxDetailViewModel: TxViewModel {
             let iconString = NSMutableAttributedString(string: S.Symbols.narrowSpace) // space required before an attachment to apply template color (UIKit bug)
             iconString.append(NSAttributedString(attachment: icon))
             attributedString.insert(iconString, at: 0)
-            attributedString.addAttributes([.foregroundColor: UIColor.receivedGreen,
-                                            .font: UIFont.customBody(size: 0.0)],
+            attributedString.addAttributes([.foregroundColor: UIColor.receivedGreen],
                                            range: NSRange(location: 0, length: iconString.length))
             return attributedString
         } else {


### PR DESCRIPTION
Fixed issue from old breadwallet-ios repo(https://github.com/breadwallet/breadwallet-ios/issues/197).
The complete text overlaps with the tick icon on transaction details screen.